### PR TITLE
Environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provides base functionality for Dropwizard projects. Features extended onto the 
 To run the demo use the following:
 
 ```bash
-$> docker run -p 8080:8080 -p 8081:8081 cuzz22000/dropwizard-ornament:latest
+$> docker run -p 8080:8080 -p 8081:8081 -e ENVIRONMENT=local cuzz22000/dropwizard-ornament:latest
 ```
 
 #### Creating a new project

--- a/configuration.yml
+++ b/configuration.yml
@@ -1,4 +1,4 @@
-configuredProperty: ${DYNAMIC_PROPERTY}
+environment: ${ENVIRONMENT}
 
 authenticationToken : foobar!
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-dropwizardVersion=1.3.2
+dropwizardVersion=1.3.3

--- a/src/main/java/io/dropwizard/ornament/ServiceApplication.java
+++ b/src/main/java/io/dropwizard/ornament/ServiceApplication.java
@@ -9,6 +9,8 @@ import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.ornament.health.ServiceHeath;
 import io.dropwizard.ornament.sample.SampleResource;
 import io.dropwizard.setup.Bootstrap;
@@ -26,6 +28,9 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
   @Override
   public void initialize(Bootstrap<ServiceConfiguration> bootstrap) {
 
+    bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(
+        bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor()));
+
     // dropwizard-swagger
     bootstrap.addBundle(new SwaggerBundle<ServiceConfiguration>() {
       @Override
@@ -39,8 +44,7 @@ public class ServiceApplication extends Application<ServiceConfiguration> {
 
   @Override
   public void run(ServiceConfiguration configuration, Environment environment) throws Exception {
-    LOG.info("Service Name : {}", System.getenv("APPLICATION"));
-    LOG.info("Environment : {}", System.getenv("ENVIRONMENT"));
+    LOG.info("Environment : {}", configuration.environment());
     // default health check
     environment.healthChecks().register(getName() + " HealthCheck", new ServiceHeath());
     environment.jersey().register(new ServiceHeath());

--- a/src/main/java/io/dropwizard/ornament/ServiceConfiguration.java
+++ b/src/main/java/io/dropwizard/ornament/ServiceConfiguration.java
@@ -9,17 +9,17 @@ import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 public class ServiceConfiguration extends Configuration {
 
   private final SwaggerBundleConfiguration swaggerBundleConfiguration;
-  private final String configuredProperty;
   private final String authenticationToken;
+  private final String environment;
 
   @JsonCreator
   public ServiceConfiguration(
       @JsonProperty(SWAGGER) final SwaggerBundleConfiguration swaggerBundleConfiguration,
-      @JsonProperty(CONFIGURED_PROPERTY_NAME) final String configuredProperty,
-      @JsonProperty(AUTH_TOKEN) final String authenticationToken) {
+      @JsonProperty(AUTH_TOKEN) final String authenticationToken,
+      @JsonProperty(ENVIRONMENT) final String environment) {
     this.swaggerBundleConfiguration = swaggerBundleConfiguration;
-    this.configuredProperty = configuredProperty;
     this.authenticationToken = authenticationToken;
+    this.environment = environment;
   }
 
   @JsonProperty(SWAGGER)
@@ -27,18 +27,19 @@ public class ServiceConfiguration extends Configuration {
     return this.swaggerBundleConfiguration;
   }
 
-  @JsonProperty(CONFIGURED_PROPERTY_NAME)
-  public String configuredProperty() {
-    return this.configuredProperty;
-  }
 
   @JsonProperty(AUTH_TOKEN)
   public String authenticationToken() {
     return this.authenticationToken;
   }
 
+  @JsonProperty(ENVIRONMENT)
+  public String environment() {
+    return this.environment;
+  }
+
+  private static final String ENVIRONMENT = "environment";
   private static final String AUTH_TOKEN = "authenticationToken";
   private static final String SWAGGER = "swagger";
-  private static final String CONFIGURED_PROPERTY_NAME = "configuredProperty";
 
 }


### PR DESCRIPTION
Introduces [environment variable resolution](https://www.dropwizard.io/0.8.0/docs/manual/core.html#environment-variables) for configuration files. This was implemented to resolve the application environment when deployed and defaults to `local`.  When running from the docker container the env variable must be provided by including `-e ENVIRONMENT=local`. 

Bumped to latest DW release 1.3.3