### PR TITLE
bumped version for Dropwizard and swagger

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-dropwizardVersion=1.3.3
+dropwizardVersion=1.3.20

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -10,7 +10,7 @@ dependencies {
   compile(
       [group: 'io.dropwizard', name: 'dropwizard-core', version: dropwizardVersion],
       [group: 'io.dropwizard', name: 'dropwizard-client', version: dropwizardVersion],
-      [group: 'com.smoketurner', name: 'dropwizard-swagger', version: '1.3.1-1'],
+      [group: 'com.smoketurner', name: 'dropwizard-swagger', version: '1.3.17-1'],
       [group: 'com.netflix.archaius', name: 'archaius2-core', version: '2.3.16']
       )
 


### PR DESCRIPTION
Bumped version for Dropwizard to the latest 1.3.x releases. 
Bumped version for Swagger to support newer version of Dropwizard